### PR TITLE
Use plain variables

### DIFF
--- a/output.tf
+++ b/output.tf
@@ -1,14 +1,14 @@
 output "arn" {
   description = "The ARN of IAM Role"
-  value       = "${aws_iam_role.this.arn}"
+  value       = aws_iam_role.this.arn
 }
 
 output "unique_id" {
   description = "The ARN Unique ID of IAM Role"
-  value       = "${aws_iam_role.this.unique_id}"
+  value       = aws_iam_role.this.unique_id
 }
 
 output "profile_name" {
   description = "The Instance profile Name"
-  value       = "${aws_iam_instance_profile.this.name}"
+  value       = aws_iam_instance_profile.this.name
 }


### PR DESCRIPTION
Interpolation throws warnings in 0.13 and isn't needed since 0.12.